### PR TITLE
Implementation for automatically reading optional files

### DIFF
--- a/RiotAsset.js
+++ b/RiotAsset.js
@@ -9,7 +9,7 @@ class RiotAsset extends Asset {
   }
 
   async generate() {
-    const riotOpts = {};
+    const riotOpts = (await this.getConfig(['.riotrc', '.riotrc.js', 'riot.config.js'])) || {};
 
     let code = compile(this.contents, riotOpts, this.name);
     code = `${ preamble }${ code }`;


### PR DESCRIPTION
It automatically loads the compile options described in `.riotrc`, `.riotrc.js`, `riot.config.js`.
This function is useful for writing tag files in `jade`/`pug` notation.

Please see here for compile options: https://riot.js.org/guide/compiler/#pre-compilation

The setting file read function is here: https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/Asset.js#L137

( I'm writing this using a translating machine. )